### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=justin@ufire.co
 sentence=Monitor hydroponic nutrient levels, salinity levels in aquariums or the ocean, saltwater pools, soil salinity, water quality etc.
 paragraph=Measures Electrical Conductivity in Siemens, Total Dissolved Solids in PPM, Salinity in PSU and PPT
 category=Sensors
-url=ufire.co
+url=https://ufire.co
 architectures=*


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.